### PR TITLE
Fix routeHook callback context

### DIFF
--- a/src/routing.js
+++ b/src/routing.js
@@ -144,11 +144,11 @@ module.exports = function(Vue, page, utils) {
             if(method) {
                 if(utils.toString.call(method) == '[object String]') {
                     if(this.vm.$root[method]) {
-                        this.vm.$root[method].apply(this.vm, params);
+                        this.vm.$root[method].apply(this.vm.$root, params);
                     }
                 }
                 else {
-                    method.apply(params);
+                    method.apply(this.vm.$root, params);
                 }
             }
 


### PR DESCRIPTION
The context wasn't the same depending on the way we listen the `update` hook.
Now it applies `$root` as context to the hook handler.
